### PR TITLE
bugfix: 修复when的变量丢失问题；适配step0之前的内容

### DIFF
--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -509,7 +509,7 @@ export class Player extends HTMLDivElement {
 				const params = ["topVars", "event", "trigger", "player", "resultEvent"];
 				const body = `var { ${deconstructs.join(", ")} } = event;\n` + `var { ${topVars.join(", ")} } = topVars;\n` + `var { result } = resultEvent;\n${varstr}\n\n` + code + `\nreturn event.next[event.next.length - 1];`;
 
-				return new Function(...params, body).bind({ lib, game, ui, get, ai, _status });
+				return new Function(...params, body).bind(null, { lib, game, ui, get, ai, _status });
 			};
 			const contents = [];
 			contents.push(


### PR DESCRIPTION
<!-- 在提交PR之前，请确保检查清单框都经过了检查 -->

### PR受影响的平台
<!-- PR的内容涉及到哪些客户端? 浏览器端，电脑端(win, mac), 手机端(android, ios, other)或者是所有平台 -->
所有


### 诱因和背景
<!-- 为什么需要进行此更改？它解决了什么问题？ -->
<!-- 如果它修复了一个未解决的issue，请在此处链接到该issue。 -->
如标题哦


### PR描述
<!-- 详细描述您的更改 -->
对于很邪门的写在step0的代码进行了适配喵
另外修复了when的bug喵


### PR测试
<!-- 请详细描述您是如何测试PR中更改的代码的？ -->
实际测试通过，工作正常喵


### 扩展适配
<!-- 如果此PR需要相当一部分扩展进行跟进或者需要UI扩展更新，请在此写出扩展跟进代码 -->
无


### 检查清单
<!-- 请在`[]`中加一个`x`来勾选方框且周围没有空格，如下所示：`[x]` -->
- [x] 我已经进行了充足的测试，且现有的测试都已通过
- [x] 如果此次PR中添加了新的武将/新的语音文件，则我已在`character/rank.js`中添加对应的武将强度评级/在`lib.translate`中加入语音文件的文字台词
- [x] 如果此次PR涉及到新功能的添加，我已在`PR描述`中写入详细文档
- [x] 如果此次PR需要扩展跟进，我已在`扩展适配`中写入详细文档
- [x] 如果这个PR解决了一个issue，我在`诱因和背景`中明确链接到该issue
- [x] 我保证该PR中没有随意修改换行符等内容，没有制造出大量的Diff
- [ ] 我保证该PR遵循项目中`.editorconfig`、`eslint.config.mjs`和`prettier.config.mjs`所规定的代码样式，并且已经通过`prettier`格式化过代码
